### PR TITLE
Public Path Fix

### DIFF
--- a/template/build/webpack.base.js
+++ b/template/build/webpack.base.js
@@ -12,7 +12,7 @@ module.exports = {
   output: {
     path: _.outputPath,
     filename: '[name].js',
-    publicPath: '/'
+    publicPath: './'
   },
   resolve: {
     extensions: ['', '.js', '.vue', '.css', '.json'],


### PR DESCRIPTION
Circumvents the need of the app build needing to be in the root directory, instead keeps the file linking to the "current directory". 


