### PR TITLE
Change publicPath for electron

### DIFF
--- a/template/build/config.js
+++ b/template/build/config.js
@@ -6,7 +6,7 @@ module.exports = {
   title: '{{name}}',
   // when you use electron please set to relative path like ./
   // otherwise only set to absolute path when you're using history mode
-  publicPath: './',
+  publicPath: '{{#if electron}}.{{/if}}/',
   // add these dependencies to a standalone vendor bundle
   vendor: Object.keys(pkg.dependencies),
   // disable babelrc by default


### PR DESCRIPTION
Set publicPath based on whether `electron` is set, so that VuePack will work out of the box when you don't want to use Electron.