### PR TITLE
Set config.cssModules to true by default

### DIFF
--- a/docs/css-modules.md
+++ b/docs/css-modules.md
@@ -16,7 +16,7 @@ If you want to use CSS modules in single file component, simply add `module` att
 </template>
 ```
 
-CSS modules is disabled in your non-vue components (eg: `import 'style.css'` in a JS file), but when you enabled JSX components in CLI prompts it will be set to `true` by default. However you can alway toggle it on and off setting `cssModules` in `./build/config.js`:
+CSS modules is disabled in your non-vue components by default (eg: `import 'style.css'` in a JS file), but when you enabled JSX components in CLI prompts it will be set to `true` by default. However you can always toggle it on and off by setting `cssModules` in `./build/config.js`:
 
 ```diff
 - cssModules: true

--- a/docs/css-modules.md
+++ b/docs/css-modules.md
@@ -1,13 +1,6 @@
 # CSS Modules
 
-[CSS Modules](https://github.com/css-modules/css-modules) is disabled by default for your non-`.vue` files. However you can enable it in `./build/config.js`:
-
-```diff
-- cssModules: false
-+ cssModules: true
-```
-
-If you want to use CSS modules in single file component, simply:
+If you want to use CSS modules in single file component, simply add `module` attribute:
 
 ```vue
 <style module>
@@ -23,4 +16,11 @@ If you want to use CSS modules in single file component, simply:
 </template>
 ```
 
-For more documentations on this, please head to http://vue-loader.vuejs.org/en/features/css-modules.html
+CSS modules is disabled in your non-vue components (eg: `import 'style.css'` in a JS file), but when you enabled JSX components in CLI prompts it will be set to `true` by default. However you can alway toggle it on and off setting `cssModules` in `./build/config.js`:
+
+```diff
+- cssModules: true
++ cssModules: false
+```
+
+For more documentations on the usage of CSS modules, please head to http://vue-loader.vuejs.org/en/features/css-modules.html

--- a/template/build/config.js
+++ b/template/build/config.js
@@ -19,8 +19,8 @@ module.exports = {
       browsers: ['last 2 versions', 'ie > 8']
     }),
     require('postcss-nested')
-  ],
-  cssModules: true,{{#if electron}}
+  ],{{#if electron}}
   electron: true,{{/if}}{{#if jsx}}
+  cssModules: true,
   jsx: true{{/if}}
 }

--- a/template/build/config.js
+++ b/template/build/config.js
@@ -20,7 +20,7 @@ module.exports = {
     }),
     require('postcss-nested')
   ],
-  cssModules: false,{{#if electron}}
+  cssModules: true,{{#if electron}}
   electron: true,{{/if}}{{#if jsx}}
   jsx: true{{/if}}
 }


### PR DESCRIPTION
The **Counter** component uses CSS Modules – `<div class={style.counter}>`.

Since Counter is rendered as part of the default template, I think it would help newbies to enable CSS Modules, just in case they can't figure out why their CSS Modules aren't working.